### PR TITLE
Initial implementation, clean-up necessary

### DIFF
--- a/gensnroses/code/LICENSE
+++ b/gensnroses/code/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2017, Jacob Stanley
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Jacob Stanley nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gensnroses/code/Setup.hs
+++ b/gensnroses/code/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/gensnroses/code/rose.cabal
+++ b/gensnroses/code/rose.cabal
@@ -1,0 +1,22 @@
+name:                rose
+version:             0.0
+synopsis:            Code for Gens'n'Roses
+homepage:            https://github.com/jystic/papers/tree/master/gensnroses
+license:             BSD3
+license-file:        LICENSE
+author:              Jacob Stanley
+maintainer:          Jacob Stanley <jacob@stanley.io>
+category:            Testing
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:    src
+  default-language:  Haskell2010
+
+  exposed-modules:   Rose
+
+  build-depends:     base
+                   , mmorph
+                   , random
+                   , transformers

--- a/gensnroses/code/src/Rose.hs
+++ b/gensnroses/code/src/Rose.hs
@@ -1,0 +1,499 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wall #-}
+module Rose where
+
+import           Control.Monad (liftM, ap, forM_, when)
+import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Morph (MFunctor(..))
+import           Control.Monad.Trans.Class (MonadTrans(..))
+import           Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
+import           Control.Monad.Trans.Writer.Lazy (WriterT(..), tell)
+
+import           Data.Bifunctor (bimap, second)
+import           Data.Functor.Classes (Show1(..), showsPrec1)
+import           Data.Functor.Classes (showsUnaryWith, showsBinaryWith)
+
+import qualified System.Random as Random
+
+
+------------------------------------------------------------------------
+-- Seed
+
+newtype Seed =
+  Seed Random.StdGen
+
+newSeed :: IO Seed
+newSeed =
+  fmap Seed Random.newStdGen
+
+splitSeed :: Seed -> (Seed, Seed)
+splitSeed (Seed s) =
+  bimap Seed Seed $ Random.split s
+
+nextInteger :: Integer -> Integer -> Seed -> (Integer, Seed)
+nextInteger lo hi (Seed s) =
+  second Seed $ Random.randomR (lo, hi) s
+
+------------------------------------------------------------------------
+-- GenT
+
+newtype GenT m a =
+  GenT (Seed -> m a)
+
+runGenT :: Seed -> GenT m a -> m a
+runGenT seed (GenT m) =
+  m seed
+
+mapGenT :: (m a -> n b) -> GenT m a -> GenT n b
+mapGenT f (GenT m) =
+  GenT $ \s ->
+    f (m s)
+
+sampleGenT :: MonadIO m => GenT m a -> m a
+sampleGenT gen = do
+  seed <- liftIO newSeed
+  runGenT seed gen
+
+instance Monad m => Monad (GenT m) where
+  return =
+    GenT . const . return
+
+  (>>=) m k =
+    GenT $ \s ->
+      case splitSeed s of
+        (sk, sm) ->
+          runGenT sk . k =<<
+          runGenT sm m
+
+instance MonadTrans GenT where
+  lift =
+    GenT . const
+
+instance MFunctor GenT where
+  hoist =
+    mapGenT
+
+instance MonadIO m => MonadIO (GenT m) where
+  liftIO =
+    lift . liftIO
+
+instance Monad m => Functor (GenT m) where
+  fmap =
+    liftM
+
+instance Monad m => Applicative (GenT m) where
+  pure =
+    return
+  (<*>) =
+    ap
+
+------------------------------------------------------------------------
+-- TreeT
+
+data Node m a =
+  Node a [TreeT m a]
+
+newtype TreeT m a =
+  TreeT (m (Node m a))
+
+runTreeT :: TreeT m a -> m (Node m a)
+runTreeT (TreeT m) =
+  m
+
+instance Monad m => Functor (Node m) where
+  fmap f (Node x xs) =
+    Node (f x) (fmap (fmap f) xs)
+
+instance Monad m => Monad (TreeT m) where
+  return x =
+    TreeT $
+      return (Node x [])
+
+  (>>=) m k =
+    TreeT $ do
+      Node x xs <- runTreeT m
+      Node y ys <- runTreeT (k x)
+      return . Node y $
+        fmap (>>= k) xs ++ ys
+
+instance MonadTrans TreeT where
+  lift m =
+    TreeT $ do
+      x <- m
+      return (Node x [])
+
+instance MFunctor TreeT where
+  hoist f (TreeT m) =
+    let
+      hoistNode (Node x xs) =
+        Node x (fmap (hoist f) xs)
+    in
+      TreeT . f $ fmap hoistNode m
+
+instance MonadIO m => MonadIO (TreeT m) where
+  liftIO =
+    lift . liftIO
+
+instance Monad m => Functor (TreeT m) where
+  fmap =
+    liftM
+
+instance Monad m => Applicative (TreeT m) where
+  pure =
+    return
+  (<*>) =
+    ap
+
+unfoldTree :: Monad m => (b -> a) -> (b -> [b]) -> b -> TreeT m a
+unfoldTree f g x =
+  TreeT . return $
+    Node (f x) (unfoldForest f g x)
+
+unfoldForest :: Monad m => (b -> a) -> (b -> [b]) -> b -> [TreeT m a]
+unfoldForest f g =
+  fmap (unfoldTree f g) . g
+
+expandTree :: Monad m => (a -> [a]) -> TreeT m a -> TreeT m a
+expandTree f m =
+  TreeT $ do
+    Node x xs <- runTreeT m
+    return . Node x $
+      fmap (expandTree f) xs ++ unfoldForest id f x
+
+pruneTree :: Monad m => TreeT m a -> TreeT m a
+pruneTree (TreeT m) =
+  TreeT $ do
+    Node x _ <- m
+    return $ Node x []
+
+------------------------------------------------------------------------
+-- Shrinking
+
+towards :: Integral a => a -> a -> [a]
+towards destination x =
+  if destination == x then
+    []
+  else
+    let
+      -- We need to halve our operands before subtracting them as they may be
+      -- using the full range of the type (i.e. 'minBound' and 'maxBound' for
+      -- 'Int32')
+      diff =
+        (x `quot` 2) - (destination `quot` 2)
+    in
+      -- We make up for halving the inputs by explicitly prepending the
+      -- destination as the first element of the list.
+      destination `consNub` fmap (x -) (halves diff)
+
+consNub :: Eq a => a -> [a] -> [a]
+consNub x ys0 =
+  case ys0 of
+    [] ->
+      x : []
+    y : ys ->
+      if x == y then
+        y : ys
+      else
+        x : y : ys
+
+halves :: Integral a => a -> [a]
+halves =
+  takeWhile (/= 0) . iterate (`quot` 2)
+
+------------------------------------------------------------------------
+-- Combinators - Shrinking
+
+shrink :: Monad m => (a -> [a]) -> GenT (TreeT m) a -> GenT (TreeT m) a
+shrink =
+  mapGenT . expandTree
+
+noShrink :: Monad m => GenT (TreeT m) a -> GenT (TreeT m) a
+noShrink =
+  mapGenT pruneTree
+
+------------------------------------------------------------------------
+-- Combinators - Ranges
+
+integral_ :: (Monad m, Integral a) => a -> a -> GenT m a
+integral_ lo hi =
+  GenT $
+    return . fromInteger . fst .
+      nextInteger (toInteger lo) (toInteger hi)
+
+integral :: (Monad m, Integral a) => a -> a -> GenT (TreeT m) a
+integral lo hi =
+  shrink (towards lo) $ integral_ lo hi
+
+enum :: (Monad m, Enum a) => a -> a -> GenT (TreeT m) a
+enum lo hi =
+  fmap toEnum $ integral (fromEnum lo) (fromEnum hi)
+
+element :: Monad m => [a] -> GenT (TreeT m) a
+element [] = error "Rose.element: used with empty list"
+element xs = do
+  n <- integral 0 (length xs - 1)
+  return $ xs !! n
+
+choice :: Monad m => [GenT (TreeT m) a] -> GenT (TreeT m) a
+choice [] = error "Rose.choice: used with empty list"
+choice xs = do
+  n <- integral 0 (length xs - 1)
+  xs !! n
+
+------------------------------------------------------------------------
+-- Tree - Show/Show1 instances, rendering
+
+instance (Show1 m, Show a) => Show (Node m a) where
+  showsPrec =
+    showsPrec1
+
+instance (Show1 m, Show a) => Show (TreeT m a) where
+  showsPrec =
+    showsPrec1
+
+instance Show1 m => Show1 (Node m) where
+  liftShowsPrec sp sl d (Node x xs) =
+    let
+      sp1 =
+        liftShowsPrec sp sl
+
+      sl1 =
+        liftShowList sp sl
+
+      sp2 =
+        liftShowsPrec sp1 sl1
+    in
+      showsBinaryWith sp sp2 "Node" d x xs
+
+instance Show1 m => Show1 (TreeT m) where
+  liftShowsPrec sp sl d (TreeT m) =
+    let
+      sp1 =
+        liftShowsPrec sp sl
+
+      sl1 =
+        liftShowList sp sl
+
+      sp2 =
+        liftShowsPrec sp1 sl1
+    in
+      showsUnaryWith sp2 "TreeT" d m
+
+--
+-- Rendering implementation based on the one from containers/Data.Tree
+--
+
+renderTreeLines :: Monad m => TreeT m String -> m [String]
+renderTreeLines (TreeT m) = do
+  Node x xs0 <- m
+  xs <- renderForestLines xs0
+  return $
+    lines (renderNode x) ++ xs
+
+renderNode :: String -> String
+renderNode xs =
+  case xs of
+    [_] ->
+      ' ' : xs
+    _ ->
+      xs
+
+renderForestLines :: Monad m => [TreeT m String] -> m [String]
+renderForestLines xs0 =
+  let
+    shift first other =
+      zipWith (++) (first : repeat other)
+  in
+    case xs0 of
+      [] ->
+        return []
+
+      [x] -> do
+        s <- renderTreeLines x
+        return $
+          shift " └╼" "   " s
+
+      x : xs -> do
+        s <- renderTreeLines x
+        ss <- renderForestLines xs
+        return $
+          shift " ├╼" " │ " s ++ ss
+
+renderTree :: Monad m => TreeT m String -> m String
+renderTree =
+  fmap unlines . renderTreeLines
+
+------------------------------------------------------------------------
+-- Sampling
+
+printSample :: Show a => GenT (TreeT IO) a -> IO ()
+printSample gen = do
+  Node x ts <- runTreeT $ sampleGenT gen
+  putStrLn "=== Outcome ==="
+  putStrLn $ show x
+  putStrLn "=== Shrinks ==="
+  forM_ ts $ \t -> do
+    Node y _ <- runTreeT t
+    putStrLn $ show y
+
+printSampleTree :: Show a => GenT (TreeT IO) a -> IO ()
+printSampleTree =
+  (putStr =<<) . renderTree . fmap show . sampleGenT
+
+printSampleTree' :: Show a => Int -> GenT (TreeT IO) a -> IO ()
+printSampleTree' seed =
+  (putStr =<<) . renderTree . fmap show . runGenT (Seed $ Random.mkStdGen seed)
+
+------------------------------------------------------------------------
+-- Property
+
+data Break =
+    Failure
+  | Discard
+    deriving (Show)
+
+newtype Shrinks =
+  Shrinks Int
+  deriving (Show)
+
+data Status =
+    Failed Shrinks [String]
+  | GaveUp
+  | OK
+    deriving (Show)
+
+data Report =
+  Report {
+      reportTests :: Int
+    , reportDiscards :: Int
+    , reportStatus :: Status
+    } deriving (Show)
+
+type Property =
+  forall m. Monad m => PropertyT m ()
+
+newtype PropertyT m a =
+  PropertyT {
+      unPropertyT :: GenT (ExceptT Break (WriterT [String] (TreeT m))) a
+    } deriving (Functor, Applicative, Monad)
+
+runPropertyT :: PropertyT m a -> GenT m (Node m (Either Break a, [String]))
+runPropertyT (PropertyT p) =
+  mapGenT (runTreeT . runWriterT . runExceptT) p
+
+forAll :: (Monad m, Show a) => GenT (TreeT m) a -> PropertyT m a
+forAll gen = do
+  x <- PropertyT $ hoist (lift . lift) gen
+  counterexample (show x)
+  return x
+
+counterexample :: Monad m => String -> PropertyT m ()
+counterexample =
+  PropertyT . lift . lift . tell . pure
+
+discard :: Monad m => PropertyT m a
+discard =
+  PropertyT . lift $
+    throwE Discard
+
+failure :: Monad m => PropertyT m a
+failure =
+  PropertyT . lift $
+    throwE Failure
+
+success :: Monad m => PropertyT m ()
+success =
+  PropertyT $
+    pure ()
+
+assert :: Monad m => Bool -> PropertyT m ()
+assert b =
+  if b then
+    success
+  else
+    failure
+
+findM :: Monad m => [a] -> b -> (a -> m (Maybe b)) -> m b
+findM xs0 def p =
+  case xs0 of
+    [] ->
+      return def
+    x0 : xs ->
+      p x0 >>= \m ->
+        case m of
+          Nothing ->
+            findM xs def p
+          Just x ->
+            return x
+
+isFailure :: Node m (Either Break a, b) -> Bool
+isFailure (Node (x, _) _) =
+  case x of
+    Left Failure ->
+      True
+    _ ->
+      False
+
+takeSmallest :: Monad m => Shrinks -> Node m (Either Break (), [String]) -> m Status
+takeSmallest (Shrinks n) (Node (x, w) xs) =
+  case x of
+    Left Failure ->
+      findM xs (Failed (Shrinks n) w) $ \(TreeT m) -> do
+        node <- m
+        if isFailure node then
+          Just <$> takeSmallest (Shrinks $ n + 1) node
+        else
+          return Nothing
+
+    Left Discard ->
+      return GaveUp
+
+    Right () ->
+      return OK
+
+report :: forall m. Monad m => Int -> PropertyT m () -> GenT m Report
+report n p =
+  let
+    loop :: Int -> Int -> GenT m Report
+    loop !tests !discards =
+      if tests == n then
+        pure $ Report tests discards OK
+      else if discards >= 100 then
+        pure $ Report tests discards GaveUp
+      else do
+        node@(Node (x, _) _) <- runPropertyT p
+        case x of
+          Left Failure ->
+            Report tests discards <$> lift (takeSmallest (Shrinks 0) node)
+
+          Left Discard ->
+            loop tests (discards + 1)
+
+          Right () ->
+            loop (tests + 1) discards
+  in
+    loop 0 0
+
+check :: MonadIO m => PropertyT m () -> m Report
+check p = do
+  seed <- liftIO newSeed
+  runGenT seed $
+    report 100 p
+
+-- Try 'check prop_foo' to see what happens
+prop_foo :: Property
+prop_foo = do
+  x <- forAll $ enum 'a' 'z'
+  y <- forAll $ integral 0 50
+
+  when (y `mod` 2 == (0 :: Int))
+    discard
+
+  assert $ y < 87 && x <= 'r'


### PR DESCRIPTION
While writing this simplified implementation for the paper, I noticed that the bind for `Arbitrary` (aka `Gen (Tree a)`) is actually the same as the bind for `Gen a`, if we parameterise it by an `apply` function:

```hs
data Gen a = Gen (Seed -> a)

data Tree a = Node a [Tree a]

runGen :: Seed -> Gen a -> a
splitSeed :: Seed -> (Seed, Seed)

bindGenWith :: ((a -> b) -> ta -> tb) -> Gen ta -> (a -> Gen b) -> Gen tb
bindGenWith apply m k =
  Gen $ \s ->
    case splitSeed s of
      (sk, sm) ->
        apply (runGen sk . k) (runGen sm m)

bindGen :: Gen a -> (a -> Gen b) -> Gen b
bindGen =
  bindGenWith ($)

bindGenTree :: Gen (Tree a) -> (a -> Gen (Tree b)) -> Gen (Tree b)
bindGenTree =
  bindGenWith (=<<)
```

This was the piece of the puzzle I was missing for making `Gen` a monad transformer, something I've been trying to figure out for some time.

I decided to run with it and this is the result. I think it has the potential to offer a much cleaner way of doing monadic property testing than what QuickCheck has. The possibility of having effects inside a generator is quite exciting. It would mean you could use `GenT (StateT m)` to keep track of some information across a number of generators which might be useful.

It probably needs some tweaking as the whole "Property" section is a bit hacked together, but I think it's a good start. Having generators as a transformer meant that I could easily use `ExceptT` and `WriterT` for capturing early termination (i.e. failure/discard) and recording counterexamples.